### PR TITLE
More in place vector methods, some optimizations and tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 
 # rspec failure tracking
 .rspec_status
+
+# macos temp
+.DS_Store

--- a/spec/unit/vector2d_unary_spec.rb
+++ b/spec/unit/vector2d_unary_spec.rb
@@ -55,4 +55,14 @@ RSpec.describe Vector2D do
     include_examples 'test ratio for', 2, 2
     include_examples 'test ratio for', 3, 3
   end
+
+  shared_examples 'test perpendicular for' do |x, y|
+    include_examples 'test unary', :perp, x, y, Vector2D.new(y, -x)
+  end
+
+  describe '#perp' do
+    include_examples 'test perpendicular for', 1, 1
+    include_examples 'test perpendicular for', 2, 2
+    include_examples 'test perpendicular for', 3, 3
+  end
 end


### PR DESCRIPTION
@UalaceCafe, mostly this PR adds a bunch of `!` methods for in-place vector maths. Along the way I tweaked a few existing methods to optimize calls (e.g. de-duplicate trig functions). 

* New in-place bang functions change the vector **in-place**
  * `plus!`, `minus!`, `times!`, `divide_by!` - these take one value and detect if `Vector2D` or `Array` or other
  * `vector_cross_product!` (aka `perp!`) - modifies self with its clockwise perperndicular
  * `reverse!` (aka `negate!`) - in-place version
  * `rotate!` - in-place version
  * `rotate_around!` - in-place version
* New functions that return new vectors
  * `vector_cross_product` (aka `perp`)
  * added `initialize_copy` which is used by Ruby kernel's `dup` and `clone` so creating copies is in our control
* Optimizations
  * `constrain` - swaps `min` and `max` if needed, and uses `num.abs2` instead of `num * num`
  * `rotate` and `rotate_around` - extracted duplicate computations (e.g. `sin`, `cos`)
  * `lerp` - previously created many temp vectors; now just the one it returns
  * `refract` - extract duplicate calcs (e.g. `sqrt` and other) and use `abs2`
* DRY
  * Modified the `+`, `-`, `*` and `/` operator methods to call the new `plus!`, `minus!`, `times!` and `divide_by!` methods on a `clone` to return the new object
  * When adding a new bang method (e.g. `rotate!`) I modified the non-bang version (e.g. `rotate`) to call the bang method on a clone of self. A few methods do this, but not all yet which I'll fix up later
